### PR TITLE
[WIP] Add sample wasm-bindgen configuration

### DIFF
--- a/tlock_age/CHANGELOG.md
+++ b/tlock_age/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Add sample wasm-bindgen configuration
+
+### Fixed
+
+- Fix all panic with error handling
+
+### Changed
+
+- Update errors from anyhow to library errors
+- Update examples to use drand_core v0.0.7
+- Update benchmark with distinct lock/unlock measurements
+
 ## [0.0.2] - 2023-03-27
 
 ### Changed

--- a/tlock_age/Cargo.toml
+++ b/tlock_age/Cargo.toml
@@ -11,7 +11,8 @@ keywords = ["tlock", "cryptography", "encryption"]
 categories = ["cryptography"]
 license = "MIT"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 age = { version = "0.9.0" }
@@ -20,6 +21,7 @@ anyhow = "1.0.69"
 hex = "0.4.3"
 thiserror = "1.0.40"
 tlock = { path = "../tlock", version = "0.0.2" }
+wasm-bindgen = { version = "0.2.87", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
@@ -35,6 +37,7 @@ pprof = { version = "0.11", features = ["criterion", "flamegraph"] }
 
 [features]
 armor = ["age/armor"]
+js = ["armor", "wasm-bindgen"]
 
 [[bench]]
 name = "encrypt_decrypt"

--- a/tlock_age/src/lib_js.rs
+++ b/tlock_age/src/lib_js.rs
@@ -1,0 +1,57 @@
+use wasm_bindgen::prelude::*;
+
+impl From<crate::TLockAgeError> for JsValue {
+    fn from(source: crate::TLockAgeError) -> JsValue {
+        JsValue::from_str(&source.to_string())
+    }
+}
+
+#[wasm_bindgen]
+pub fn encrypt(
+    src: &[u8],
+    chain_hash: &[u8],
+    public_key_bytes: &[u8],
+    round: u64,
+) -> Result<Vec<u8>, JsValue> {
+    let mut encrypted = vec![];
+    crate::encrypt(
+        &mut encrypted,
+        src,
+        chain_hash,
+        public_key_bytes,
+        round,
+    )?;
+    Ok(encrypted)
+}
+
+#[wasm_bindgen(inspectable, getter_with_clone)]
+pub struct Header {
+    pub round: u64,
+    pub hash: Vec<u8>,
+}
+
+impl From<crate::Header> for Header {
+    fn from(source: crate::Header) -> Header {
+        Header {
+            round: source.round,
+            hash: source.hash,
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub fn decrypt_header(src: &[u8]) -> Result<JsValue, JsValue> {
+    let value: Header = crate::decrypt_header(src)?.into();
+    Ok(value.into())
+}
+
+#[wasm_bindgen]
+pub fn decrypt(
+    src: &[u8],
+    chain_hash: &[u8],
+    signature: &[u8],
+) -> Result<Vec<u8>, JsValue> {
+    let mut decrypted = vec![];
+    crate::decrypt(&mut decrypted, src, chain_hash, signature)?;
+    Ok(decrypted)
+}


### PR DESCRIPTION
Wrap `tlock_age` methods with wasm-bindgen to allow for a use in JavaScript and TypeScript. This is done through an optional feature `js`.
Armoring is supported.

Methods use a Uint8Array containing the full source to encrypt or decrypt. Result is returned as Uint8Array.

Two targets have been tested
- NodeJS `wasm-pack build --target nodejs -- --features js`. Then `const tlock_age = require('./pkg')`
- Web `wasm-pack build --target web -- --features js`. You can then point your bundler to use `./pkg`. Don't forget to call the default export `init()` to load the module in browser.

TODO
- Add JS use examples
- Add wasm-build documentation
- Add lib_js.rs code comment
- Add tests for JS methods